### PR TITLE
FI schema bug fixes for Deposit, TD, RD

### DIFF
--- a/schemas/deposit/deposit.xsd
+++ b/schemas/deposit/deposit.xsd
@@ -124,7 +124,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Pending"/>
+        <xs:element ref="aa:Pending" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute name="currentBalance" use="required" type="xs:string">
         <xs:annotation>
@@ -141,7 +141,7 @@
           <xs:documentation xml:lang="en"> Currency conversion exchange rate for the day.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="balanceDateTime" use="required" type="xs:dateTimeStamp">
+      <xs:attribute name="balanceDateTime" use="required" type="xs:dateTime">
         <xs:annotation>
           <xs:documentation xml:lang="en"> Date and time stamp for which current balance recorded.</xs:documentation>
         </xs:annotation>
@@ -157,7 +157,7 @@
           <xs:documentation xml:lang="en">Location of branch where investment was made</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="facility" use="required" type="aa:SummaryFacility">
+      <xs:attribute name="facility" use="optional" type="aa:SummaryFacility">
         <xs:annotation>
           <xs:documentation> Additional facility like Overdraft or Sweep In applicable for the given account. </xs:documentation>
         </xs:annotation>
@@ -174,17 +174,17 @@
             in an ECS.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="openingDate" use="required" type="xs:string">
+      <xs:attribute name="openingDate" use="required" type="xs:date">
         <xs:annotation>
           <xs:documentation>Opening date of the deposit account</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="currentODLimit" use="required" type="xs:string">
+      <xs:attribute name="currentODLimit" use="optional" type="xs:string">
         <xs:annotation>
           <xs:documentation xml:lang="en">The portion of the sanctioned limit that is available to be drawn, as of this point in time</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="drawingLimit" use="required" type="xs:string">
+      <xs:attribute name="drawingLimit" use="optional" type="xs:string">
         <xs:annotation>
           <xs:documentation xml:lang="en"> Sanctioned limit (overall limit given by the bank, on the OD/CC facility). </xs:documentation>
         </xs:annotation>
@@ -202,7 +202,7 @@
   <xs:element name="Holders">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Holder"/>
+        <xs:element ref="aa:Holder" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="aa:HoldersType">
         <xs:annotation>
@@ -236,7 +236,7 @@
           <xs:documentation xml:lang="en"> Status of nominee registred with the account.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="landline" type="xs:string">
+      <xs:attribute name="landline" use="optional" type="xs:string">
         <xs:annotation>
           <xs:documentation xml:lang="en"> Landline number of account holder.</xs:documentation>
         </xs:annotation>
@@ -246,17 +246,17 @@
           <xs:documentation xml:lang="en">  Address of account holder.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="email" use="required" type="aa:HolderEmail">
+      <xs:attribute name="email" use="optional" type="aa:HolderEmail">
         <xs:annotation>
           <xs:documentation xml:lang="en"> Email ID of primary account holder.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="pan" use="required" type="aa:HolderPan">
+      <xs:attribute name="pan" use="optional" type="aa:HolderPan">
         <xs:annotation>
           <xs:documentation xml:lang="en"> PAN number of primary account holder.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="ckycCompliance" use="required" type="xs:boolean">
+      <xs:attribute name="ckycCompliance" use="optional" type="xs:boolean">
         <xs:annotation>
           <xs:documentation xml:lang="en"> KYC status whether its completed or pending </xs:documentation>
         </xs:annotation>
@@ -269,7 +269,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Transaction"/>
+        <xs:element ref="aa:Transaction" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="startDate" use="required" type="xs:date">
         <xs:annotation>
@@ -305,7 +305,7 @@
           <xs:documentation xml:lang="en">Available balance.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="transactionTimestamp" use="required" type="xs:dateTimeStamp">
+      <xs:attribute name="transactionTimestamp" use="required" type="xs:dateTime">
         <xs:annotation>
           <xs:documentation xml:lang="en">Transaction date time stamp for particular record when transaction taken place</xs:documentation>
         </xs:annotation>

--- a/schemas/recurring_deposit/recurring_deposit.xsd
+++ b/schemas/recurring_deposit/recurring_deposit.xsd
@@ -89,9 +89,9 @@
   <xs:element name="Account">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Profile" minOccurs="0"/>
-        <xs:element ref="aa:Summary" minOccurs="0"/>
-        <xs:element ref="aa:Transactions"/>
+        <xs:element ref="aa:Profile" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="aa:Summary" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="aa:Transactions" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="xs:NCName" fixed="recurring_deposit"/>
       <xs:attribute name="maskedAccNumber" type="xs:string" use="required"/>
@@ -125,7 +125,7 @@
           <xs:documentation xml:lang="en">Location of branch where investment was made</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="openingDate" type="xs:string" use="required">
+      <xs:attribute name="openingDate" type="xs:date" use="required">
         <xs:annotation>
           <xs:documentation>Opening date of the deposit account</xs:documentation>
         </xs:annotation>
@@ -225,7 +225,7 @@
   <xs:element name="Holders">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Holder"/>
+        <xs:element ref="aa:Holder" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="aa:HoldersType">
         <xs:annotation>
@@ -256,7 +256,7 @@
           <xs:documentation> Name of nominee registered for the account </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="landline" type="xs:string">
+      <xs:attribute name="landline" use="optional" type="xs:string">
         <xs:annotation>
           <xs:documentation> Landline number of account holder</xs:documentation>
         </xs:annotation>
@@ -266,17 +266,17 @@
           <xs:documentation> address of account holder</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="email" use="required" type="aa:HolderEmail">
+      <xs:attribute name="email" use="optional" type="aa:HolderEmail">
         <xs:annotation>
           <xs:documentation> Email ID of primary account holder </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="pan" use="required" type="aa:HolderPan">
+      <xs:attribute name="pan" use="optional" type="aa:HolderPan">
         <xs:annotation>
           <xs:documentation> PAN number of primary account holder</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="ckycCompliance" use="required" type="xs:boolean">
+      <xs:attribute name="ckycCompliance" use="optional" type="xs:boolean">
         <xs:annotation>
           <xs:documentation> KYC status whether its completed or pending </xs:documentation>
         </xs:annotation>
@@ -291,7 +291,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Transaction"/>
+        <xs:element ref="aa:Transaction" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="startDate" use="required" type="xs:date">
         <xs:annotation>
@@ -337,12 +337,12 @@
           <xs:documentation> Current value of investment</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="transactionDateTime" type="xs:dateTimeStamp" use="required">
+      <xs:attribute name="transactionDateTime" type="xs:dateTime" use="required">
         <xs:annotation>
           <xs:documentation> Transaction date time stamp for particular record when investment taken place </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="valueDate" type="xs:dateTimeStamp" use="required">
+      <xs:attribute name="valueDate" type="xs:date" use="required">
         <xs:annotation>
           <xs:documentation> Date when the transaction actually carries out. For example., cheque realization. </xs:documentation>
         </xs:annotation>

--- a/schemas/term_deposit/term_deposit.xsd
+++ b/schemas/term_deposit/term_deposit.xsd
@@ -102,9 +102,9 @@
   <xs:element name="Account">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Profile" minOccurs="0"/>
-        <xs:element ref="aa:Summary" minOccurs="0"/>
-        <xs:element ref="aa:Transactions"/>
+        <xs:element ref="aa:Profile" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="aa:Summary" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="aa:Transactions" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="xs:NCName" fixed="term_deposit"/>
       <xs:attribute name="maskedAccNumber" type="xs:string" use="required"/>
@@ -138,7 +138,7 @@
           <xs:documentation xml:lang="en">Name of the brach</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="openingDate" type="xs:string" use="required">
+      <xs:attribute name="openingDate" type="xs:date" use="required">
         <xs:annotation>
           <xs:documentation>Opening date of the deposit account</xs:documentation>
         </xs:annotation>
@@ -228,7 +228,7 @@
   <xs:element name="Holders">
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Holder"/>
+        <xs:element ref="aa:Holder" minOccurs="1" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="type" use="required" type="aa:HoldersType"/>
     </xs:complexType>
@@ -255,7 +255,7 @@
           <xs:documentation> Name of nominee associated with the account.  </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="landline" type="xs:string">
+      <xs:attribute name="landline" type="xs:string" use="optional">
         <xs:annotation>
           <xs:documentation> Landline of primary account holder.   </xs:documentation>
         </xs:annotation>
@@ -265,17 +265,17 @@
           <xs:documentation> Address of primary account holder  </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="email" use="required" type="aa:HolderEmail">
+      <xs:attribute name="email" use="optional" type="aa:HolderEmail">
         <xs:annotation>
           <xs:documentation> Email ID of primary account holder  </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="pan" use="required" type="aa:HolderPan">
+      <xs:attribute name="pan" use="optional" type="aa:HolderPan">
         <xs:annotation>
           <xs:documentation> PAN number of primary account holder </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="ckycCompliance" use="required" type="xs:boolean">
+      <xs:attribute name="ckycCompliance" use="optional" type="xs:boolean">
         <xs:annotation>
           <xs:documentation> KYC status whether its completed or pending </xs:documentation>
         </xs:annotation>
@@ -289,7 +289,7 @@
     </xs:annotation>
     <xs:complexType>
       <xs:sequence>
-        <xs:element ref="aa:Transaction"/>
+        <xs:element ref="aa:Transaction" minOccurs="0" maxOccurs="unbounded"/>
       </xs:sequence>
       <xs:attribute name="startDate" use="required" type="xs:date">
         <xs:annotation>
@@ -335,12 +335,12 @@
           <xs:documentation> Current value of investment </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="transactionDateTime" type="xs:dateTimeStamp" use="required">
+      <xs:attribute name="transactionDateTime" type="xs:dateTime" use="required">
         <xs:annotation>
           <xs:documentation> Transaction date time stamp for particular record when investment taken place.  </xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="valueDate" type="xs:dateTimeStamp" use="required">
+      <xs:attribute name="valueDate" type="xs:date" use="required">
         <xs:annotation>
           <xs:documentation> Date when the transaction actually carries out. For example., cheque realization. </xs:documentation>
         </xs:annotation>


### PR DESCRIPTION
I. deposit.xsd:

1. Allow 0 to Unbounded Transaction elements.
2. Allow 1 to Unbounded Holder elements.
3. Allow 0 to 1 in Pending element
4. Make following fields optional.
	- facility
	- currentODLimit
	- drawingLimit
	- pan
	- landline
	- email
	- ckycCompliance
5. Modify datatype to support W3 org XML Shema 1.1
	- balanceDatetime:dateTime
	- transactionTimestamp:dateTime
6. Change openingDate from xs:string to xs:date 

II. term_deposit.xsd:

1. Allow 0 to Unbounded Transaction elements.
2. Allow 1 to Unbounded Holder elements.
3. Make following fields optional.
	- pan
	- email
	- ckycCompliance
	- landline
4. Modify datatype to support W3 org XML Shema 1.1
	- valueDate:dateTime
	- transactionDateTime:dateTime
5. Set profile, summary, transactions elements minOccurs 0 and maxOccurs 1.
6. Change openingDate from xs:string to xs:date 
7. Change valueDate from xs:datetime to xs:date

III. recurring_deposit.xsd:

1. Allow 0 to Unbounded Transaction elements.
2. Allow 1 to Unbounded Holder elements.
3. Make following fields optional.
	- pan
	- email
	- ckycCompliance
	- landline
4. Modify datatype to support W3 org XML Shema 1.1
	- valueDate:dateTime
	- transactionDateTime:dateTime
5. Set profile, summary, transactions elements minOccurs 0 and maxOccurs 1.
6. Change openingDate from xs:string to xs:date 
7. Change valueDate from xs:datetime to xs:date
