### PR TITLE
bug: typo in ULIP schema

### DIFF
--- a/schemas/unit_linked_insurance_plan/others_ulip.xsd
+++ b/schemas/unit_linked_insurance_plan/others_ulip.xsd
@@ -44,7 +44,7 @@
     </xs:restriction>
   </xs:simpleType>
 
-  <xs:simpleType name="  PremiumFrequencyType">
+  <xs:simpleType name="PremiumFrequencyType">
     <xs:restriction base="xs:string">
       <xs:enumeration value="MONTHLY"/>
       <xs:enumeration value="QUARTERLY"/>


### PR DESCRIPTION
fixed whitespace typo in ULIP xsd's PremiumFrequencyType simpleType

Closes #15 